### PR TITLE
Add tuner gauge UI with needle, note display, and cents readout

### DIFF
--- a/frontend/src/lib/components/tuner/CalibrationControl.svelte
+++ b/frontend/src/lib/components/tuner/CalibrationControl.svelte
@@ -1,0 +1,111 @@
+<script lang="ts">
+	import { CALIBRATION_MIN, CALIBRATION_MAX } from '$lib/tuner-geometry';
+
+	interface Props {
+		pitchCenter: number;
+		onPitchCenterChange: (value: number) => void;
+	}
+
+	let { pitchCenter, onPitchCenterChange }: Props = $props();
+
+	let showStepper = $state(false);
+
+	function selectPreset(value: number) {
+		onPitchCenterChange(value);
+	}
+
+	function increment() {
+		if (pitchCenter < CALIBRATION_MAX) {
+			onPitchCenterChange(pitchCenter + 1);
+		}
+	}
+
+	function decrement() {
+		if (pitchCenter > CALIBRATION_MIN) {
+			onPitchCenterChange(pitchCenter - 1);
+		}
+	}
+</script>
+
+<div class="flex flex-col items-center gap-2">
+	<div class="flex items-center gap-2">
+		<!-- A432 preset -->
+		<button
+			onclick={() => selectPreset(432)}
+			class="rounded-full border px-3 py-1.5 text-xs font-medium transition-all duration-200
+				{pitchCenter === 432
+				? 'border-accent-amber/50 bg-accent-amber/15 text-accent-amber'
+				: 'border-border-default bg-bg-surface/50 text-text-secondary hover:border-accent-amber/30 hover:text-text-primary'}"
+			style="min-height: 44px; min-width: 44px;"
+		>
+			A432
+		</button>
+
+		<!-- A440 preset -->
+		<button
+			onclick={() => selectPreset(440)}
+			class="rounded-full border px-3 py-1.5 text-xs font-medium transition-all duration-200
+				{pitchCenter === 440
+				? 'border-accent-amber/50 bg-accent-amber/15 text-accent-amber'
+				: 'border-border-default bg-bg-surface/50 text-text-secondary hover:border-accent-amber/30 hover:text-text-primary'}"
+			style="min-height: 44px; min-width: 44px;"
+		>
+			A440
+		</button>
+
+		<!-- Gear toggle -->
+		<button
+			onclick={() => (showStepper = !showStepper)}
+			class="flex items-center justify-center rounded-full border border-border-default bg-bg-surface/50 text-text-secondary transition-all duration-200 hover:border-accent-amber/30 hover:text-text-primary"
+			style="min-height: 44px; min-width: 44px;"
+			aria-label="Custom pitch reference"
+		>
+			<svg width="16" height="16" viewBox="0 0 24 24" fill="none">
+				<path
+					d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"
+					stroke="currentColor"
+					stroke-width="1.5"
+				/>
+				<circle cx="12" cy="12" r="3" stroke="currentColor" stroke-width="1.5" />
+			</svg>
+		</button>
+	</div>
+
+	<!-- Stepper (hidden by default) -->
+	{#if showStepper}
+		<div class="flex items-center gap-3">
+			<button
+				onclick={decrement}
+				disabled={pitchCenter <= CALIBRATION_MIN}
+				class="flex items-center justify-center rounded-full border border-border-default bg-bg-surface/50 text-text-secondary transition-all duration-200 hover:border-accent-amber/30 hover:text-text-primary disabled:opacity-30 disabled:hover:border-border-default disabled:hover:text-text-secondary"
+				style="min-height: 44px; min-width: 44px;"
+				aria-label="Decrease pitch reference"
+			>
+				<svg width="16" height="16" viewBox="0 0 24 24" fill="none">
+					<path d="M5 12h14" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
+				</svg>
+			</button>
+
+			<span class="min-w-[4rem] text-center text-sm tabular-nums text-text-primary">
+				A{pitchCenter}
+			</span>
+
+			<button
+				onclick={increment}
+				disabled={pitchCenter >= CALIBRATION_MAX}
+				class="flex items-center justify-center rounded-full border border-border-default bg-bg-surface/50 text-text-secondary transition-all duration-200 hover:border-accent-amber/30 hover:text-text-primary disabled:opacity-30 disabled:hover:border-border-default disabled:hover:text-text-secondary"
+				style="min-height: 44px; min-width: 44px;"
+				aria-label="Increase pitch reference"
+			>
+				<svg width="16" height="16" viewBox="0 0 24 24" fill="none">
+					<path
+						d="M12 5v14m-7-7h14"
+						stroke="currentColor"
+						stroke-width="2"
+						stroke-linecap="round"
+					/>
+				</svg>
+			</button>
+		</div>
+	{/if}
+</div>

--- a/frontend/src/lib/components/tuner/NoteDisplay.svelte
+++ b/frontend/src/lib/components/tuner/NoteDisplay.svelte
@@ -1,0 +1,118 @@
+<script lang="ts">
+	import { centsToColorZone, centsToDirection } from '$lib/tuner-geometry';
+
+	interface Props {
+		noteName: string | null;
+		octave: number | null;
+		cents: number;
+		frequency: number | null;
+		isDetecting: boolean;
+		showFrequency: boolean;
+	}
+
+	let { noteName, octave, cents, frequency, isDetecting, showFrequency }: Props = $props();
+
+	let zone = $derived(centsToColorZone(cents));
+	let direction = $derived(centsToDirection(cents));
+
+	let centsColor = $derived(
+		zone === 'green'
+			? 'text-accent-green'
+			: zone === 'yellow'
+				? 'text-accent-amber'
+				: 'text-accent-red'
+	);
+
+	let centsSign = $derived(cents > 0 ? '+' : '');
+
+	let srAnnouncement = $derived(
+		isDetecting && noteName
+			? `${noteName}${octave}, ${centsSign}${cents} cents`
+			: 'No note detected'
+	);
+</script>
+
+<!-- Screen reader announcement -->
+<div class="sr-only" aria-live="polite" role="status">
+	{srAnnouncement}
+</div>
+
+<div class="flex flex-col items-center gap-1">
+	<!-- Directional hint -->
+	<div class="flex h-8 items-center gap-1.5">
+		{#if !isDetecting}
+			<span class="text-sm text-text-muted">&nbsp;</span>
+		{:else if direction === 'flat'}
+			<svg width="16" height="16" viewBox="0 0 24 24" fill="none" class="text-accent-amber">
+				<path
+					d="M12 19V5m-7 7 7-7 7 7"
+					stroke="currentColor"
+					stroke-width="2"
+					stroke-linecap="round"
+					stroke-linejoin="round"
+				/>
+			</svg>
+			<span class="text-sm font-medium text-accent-amber">Tune Up</span>
+		{:else if direction === 'sharp'}
+			<svg width="16" height="16" viewBox="0 0 24 24" fill="none" class="text-accent-amber">
+				<path
+					d="M12 5v14m7-7-7 7-7-7"
+					stroke="currentColor"
+					stroke-width="2"
+					stroke-linecap="round"
+					stroke-linejoin="round"
+				/>
+			</svg>
+			<span class="text-sm font-medium text-accent-amber">Tune Down</span>
+		{:else}
+			<svg width="16" height="16" viewBox="0 0 24 24" fill="none" class="text-accent-green">
+				<path
+					d="M20 6 9 17l-5-5"
+					stroke="currentColor"
+					stroke-width="2"
+					stroke-linecap="round"
+					stroke-linejoin="round"
+				/>
+			</svg>
+			<span class="text-sm font-medium text-accent-green">In Tune</span>
+		{/if}
+	</div>
+
+	<!-- Note name -->
+	<div class="flex items-baseline gap-1">
+		<span
+			class="font-display text-6xl leading-none sm:text-7xl {isDetecting && noteName
+				? 'text-text-primary'
+				: 'text-text-muted'}"
+		>
+			{isDetecting && noteName ? noteName : '--'}
+		</span>
+		{#if isDetecting && octave !== null}
+			<span class="text-2xl text-text-secondary">{octave}</span>
+		{/if}
+	</div>
+
+	<!-- Cents readout -->
+	<div class="flex h-7 items-center">
+		{#if isDetecting && noteName}
+			<span class="text-lg font-medium tabular-nums {centsColor}">
+				{centsSign}{cents} cents
+			</span>
+		{:else}
+			<span class="text-lg text-text-muted">&nbsp;</span>
+		{/if}
+	</div>
+
+	<!-- Frequency (opt-in) -->
+	{#if showFrequency}
+		<div class="h-5">
+			{#if isDetecting && frequency}
+				<span class="text-xs tabular-nums text-text-secondary">
+					{frequency.toFixed(1)} Hz
+				</span>
+			{:else}
+				<span class="text-xs text-text-muted">&nbsp;</span>
+			{/if}
+		</div>
+	{/if}
+</div>

--- a/frontend/src/lib/components/tuner/NoteDisplay.svelte
+++ b/frontend/src/lib/components/tuner/NoteDisplay.svelte
@@ -27,7 +27,7 @@
 
 	let srAnnouncement = $derived(
 		isDetecting && noteName
-			? `${noteName}${octave}, ${centsSign}${cents} cents`
+			? `${noteName}${octave ?? ''}, ${centsSign}${cents} cents`
 			: 'No note detected'
 	);
 </script>

--- a/frontend/src/lib/components/tuner/NoteDisplay.svelte
+++ b/frontend/src/lib/components/tuner/NoteDisplay.svelte
@@ -111,7 +111,7 @@
 					{frequency.toFixed(1)} Hz
 				</span>
 			{:else}
-				<span class="text-xs text-text-muted">&nbsp;</span>
+				<span class="text-xs text-text-muted">-- Hz</span>
 			{/if}
 		</div>
 	{/if}

--- a/frontend/src/lib/components/tuner/StabilityIndicator.svelte
+++ b/frontend/src/lib/components/tuner/StabilityIndicator.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+	interface Props {
+		stability: number;
+		isDetecting: boolean;
+	}
+
+	let { stability, isDetecting }: Props = $props();
+
+	let fillPercent = $derived(isDetecting ? Math.round(stability * 100) : 0);
+	let barColor = $derived(
+		stability > 0.7 ? 'bg-accent-green' : stability > 0.3 ? 'bg-accent-amber' : 'bg-accent-red'
+	);
+</script>
+
+<div
+	class="h-1.5 w-full overflow-hidden rounded-full bg-bg-elevated"
+	role="meter"
+	aria-valuenow={fillPercent}
+	aria-valuemin={0}
+	aria-valuemax={100}
+	aria-label="Signal stability"
+>
+	<div
+		class="h-full rounded-full {barColor}"
+		style="width: {fillPercent}%; transition: width 300ms ease, background-color 300ms ease;"
+	></div>
+</div>

--- a/frontend/src/lib/components/tuner/StabilityIndicator.svelte
+++ b/frontend/src/lib/components/tuner/StabilityIndicator.svelte
@@ -2,9 +2,10 @@
 	interface Props {
 		stability: number;
 		isDetecting: boolean;
+		reducedMotion: boolean;
 	}
 
-	let { stability, isDetecting }: Props = $props();
+	let { stability, isDetecting, reducedMotion }: Props = $props();
 
 	let fillPercent = $derived(isDetecting ? Math.round(stability * 100) : 0);
 	let barColor = $derived(
@@ -22,6 +23,8 @@
 >
 	<div
 		class="h-full rounded-full {barColor}"
-		style="width: {fillPercent}%; transition: width 300ms ease, background-color 300ms ease;"
+		style="width: {fillPercent}%; transition: width {reducedMotion
+			? '0ms'
+			: '300ms'} ease, background-color {reducedMotion ? '0ms' : '300ms'} ease;"
 	></div>
 </div>

--- a/frontend/src/lib/components/tuner/TunerGauge.svelte
+++ b/frontend/src/lib/components/tuner/TunerGauge.svelte
@@ -1,0 +1,178 @@
+<script lang="ts">
+	import { tweened } from 'svelte/motion';
+	import { cubicOut } from 'svelte/easing';
+	import {
+		centsToAngle,
+		centsToColorZone,
+		describeArc,
+		generateTickMarks,
+		generateColorArcs,
+		GAUGE_WIDTH,
+		GAUGE_HEIGHT,
+		GAUGE_CX,
+		GAUGE_CY,
+		GAUGE_RADIUS,
+		ANGLE_MIN,
+		ANGLE_MAX
+	} from '$lib/tuner-geometry';
+
+	interface Props {
+		cents: number;
+		stability: number;
+		isDetecting: boolean;
+		reducedMotion: boolean;
+	}
+
+	let { cents, stability, isDetecting, reducedMotion }: Props = $props();
+
+	// Static geometry — computed once
+	const ticks = generateTickMarks();
+	const colorArcs = generateColorArcs();
+	const backgroundArc = describeArc(GAUGE_CX, GAUGE_CY, GAUGE_RADIUS, ANGLE_MIN, ANGLE_MAX);
+
+	// Animated needle angle
+	const needleAngle = tweened(0, {
+		duration: 150,
+		easing: cubicOut
+	});
+
+	// Update needle when cents changes
+	$effect(() => {
+		needleAngle.set(centsToAngle(cents), {
+			duration: reducedMotion ? 0 : 150
+		});
+	});
+
+	// Derived state
+	let zone = $derived(centsToColorZone(cents));
+	let showGlow = $derived(zone === 'green' && stability > 0.7 && isDetecting);
+	let gaugeOpacity = $derived(isDetecting ? 0.8 : 0.15);
+
+	// Needle endpoint (length slightly shorter than radius)
+	const NEEDLE_LENGTH = 100;
+	const NEEDLE_PIVOT_RADIUS = 6;
+</script>
+
+<svg
+	viewBox="0 0 {GAUGE_WIDTH} {GAUGE_HEIGHT}"
+	class="w-full max-w-[400px]"
+	role="meter"
+	aria-valuenow={cents}
+	aria-valuemin={-50}
+	aria-valuemax={50}
+	aria-label="Tuning gauge"
+	style="opacity: {gaugeOpacity}; transition: opacity 300ms ease;"
+>
+	<!-- Green glow filter -->
+	<defs>
+		<filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+			<feGaussianBlur stdDeviation="4" result="blur" />
+			<feMerge>
+				<feMergeNode in="blur" />
+				<feMergeNode in="SourceGraphic" />
+			</feMerge>
+		</filter>
+	</defs>
+
+	<!-- Background arc -->
+	<path d={backgroundArc} fill="none" stroke="#2a2a24" stroke-width="3" stroke-linecap="round" />
+
+	<!-- Color zone arcs -->
+	{#each colorArcs as arc, i (i)}
+		<path
+			d={arc.d}
+			fill="none"
+			stroke={arc.color}
+			stroke-width="4"
+			stroke-linecap="round"
+			opacity="0.6"
+		/>
+	{/each}
+
+	<!-- Tick marks -->
+	{#each ticks as tick (tick.cents)}
+		<line
+			x1={tick.x1}
+			y1={tick.y1}
+			x2={tick.x2}
+			y2={tick.y2}
+			stroke={tick.major ? '#9e9a90' : '#5c5a54'}
+			stroke-width={tick.major ? 2 : 1}
+			stroke-linecap="round"
+		/>
+	{/each}
+
+	<!-- Flat / Sharp labels -->
+	<text
+		x="38"
+		y="178"
+		fill="#9e9a90"
+		font-size="10"
+		font-family="var(--font-body)"
+		text-anchor="middle">Flat</text
+	>
+	<text
+		x="262"
+		y="178"
+		fill="#9e9a90"
+		font-size="10"
+		font-family="var(--font-body)"
+		text-anchor="middle">Sharp</text
+	>
+
+	<!-- Needle group -->
+	<g
+		transform="rotate({$needleAngle}, {GAUGE_CX}, {GAUGE_CY})"
+		filter={showGlow ? 'url(#glow)' : undefined}
+	>
+		<!-- Needle line (tapered) -->
+		<line
+			x1={GAUGE_CX}
+			y1={GAUGE_CY}
+			x2={GAUGE_CX}
+			y2={GAUGE_CY - NEEDLE_LENGTH}
+			stroke={isDetecting ? '#d4a053' : '#5c5a54'}
+			stroke-width="2.5"
+			stroke-linecap="round"
+		/>
+		<!-- Needle tip (thinner) -->
+		<line
+			x1={GAUGE_CX}
+			y1={GAUGE_CY - NEEDLE_LENGTH}
+			x2={GAUGE_CX}
+			y2={GAUGE_CY - NEEDLE_LENGTH - 15}
+			stroke={isDetecting ? '#d4a053' : '#5c5a54'}
+			stroke-width="1.5"
+			stroke-linecap="round"
+		/>
+	</g>
+
+	<!-- Pivot circle -->
+	<circle
+		cx={GAUGE_CX}
+		cy={GAUGE_CY}
+		r={NEEDLE_PIVOT_RADIUS}
+		fill={isDetecting ? '#d4a053' : '#5c5a54'}
+	/>
+
+	<!-- Green glow pulse ring -->
+	{#if showGlow}
+		<circle
+			cx={GAUGE_CX}
+			cy={GAUGE_CY}
+			r={NEEDLE_PIVOT_RADIUS + 4}
+			fill="none"
+			stroke="#5cb870"
+			stroke-width="2"
+			opacity="0.5"
+		>
+			<animate
+				attributeName="r"
+				values="{NEEDLE_PIVOT_RADIUS + 4};{NEEDLE_PIVOT_RADIUS + 10};{NEEDLE_PIVOT_RADIUS + 4}"
+				dur="1.5s"
+				repeatCount="indefinite"
+			/>
+			<animate attributeName="opacity" values="0.5;0.15;0.5" dur="1.5s" repeatCount="indefinite" />
+		</circle>
+	{/if}
+</svg>

--- a/frontend/src/lib/components/tuner/TunerGauge.svelte
+++ b/frontend/src/lib/components/tuner/TunerGauge.svelte
@@ -61,7 +61,7 @@
 	aria-valuemin={-50}
 	aria-valuemax={50}
 	aria-label="Tuning gauge"
-	style="opacity: {gaugeOpacity}; transition: opacity 300ms ease;"
+	style="opacity: {gaugeOpacity}; transition: opacity {reducedMotion ? '0ms' : '300ms'} ease;"
 >
 	<!-- Green glow filter -->
 	<defs>
@@ -166,13 +166,20 @@
 			stroke-width="2"
 			opacity="0.5"
 		>
-			<animate
-				attributeName="r"
-				values="{NEEDLE_PIVOT_RADIUS + 4};{NEEDLE_PIVOT_RADIUS + 10};{NEEDLE_PIVOT_RADIUS + 4}"
-				dur="1.5s"
-				repeatCount="indefinite"
-			/>
-			<animate attributeName="opacity" values="0.5;0.15;0.5" dur="1.5s" repeatCount="indefinite" />
+			{#if !reducedMotion}
+				<animate
+					attributeName="r"
+					values="{NEEDLE_PIVOT_RADIUS + 4};{NEEDLE_PIVOT_RADIUS + 10};{NEEDLE_PIVOT_RADIUS + 4}"
+					dur="1.5s"
+					repeatCount="indefinite"
+				/>
+				<animate
+					attributeName="opacity"
+					values="0.5;0.15;0.5"
+					dur="1.5s"
+					repeatCount="indefinite"
+				/>
+			{/if}
 		</circle>
 	{/if}
 </svg>

--- a/frontend/src/lib/components/tuner/TunerStatus.svelte
+++ b/frontend/src/lib/components/tuner/TunerStatus.svelte
@@ -1,0 +1,66 @@
+<script lang="ts">
+	import type { PitchDetectorStatus } from '$lib/stores/pitch-detector';
+	import type { AudioError } from '$lib/audio-pipeline';
+
+	interface Props {
+		status: PitchDetectorStatus;
+		error: AudioError | null;
+		isDetecting: boolean;
+		onStart: () => void;
+		onStop: () => void;
+	}
+
+	let { status, error, isDetecting, onStart, onStop }: Props = $props();
+
+	const errorMessages: Record<AudioError, string> = {
+		'permission-denied':
+			'Microphone access was denied. Please allow microphone access in your browser settings.',
+		'no-microphone': 'No microphone found. Please connect a microphone and try again.',
+		'not-supported': 'Your browser does not support audio input. Please try a modern browser.',
+		unknown: 'Something went wrong accessing the microphone. Please try again.'
+	};
+
+	let errorMessage = $derived(error ? errorMessages[error] : null);
+	let showPrompt = $derived(status === 'active' && !isDetecting);
+</script>
+
+<div class="flex flex-col items-center gap-3">
+	<!-- Error message -->
+	{#if errorMessage}
+		<p class="max-w-xs text-center text-sm text-accent-red" role="alert">
+			{errorMessage}
+		</p>
+	{/if}
+
+	<!-- "Play a string..." prompt -->
+	{#if showPrompt}
+		<p class="text-sm text-text-secondary">Play a string...</p>
+	{/if}
+
+	<!-- Start / Stop button -->
+	{#if status === 'idle' || status === 'error'}
+		<button
+			onclick={onStart}
+			class="rounded-full border border-accent-green/30 bg-accent-green/15 px-8 py-3 text-sm font-medium text-accent-green transition-all duration-200 hover:border-accent-green/50 hover:bg-accent-green/25"
+			style="min-height: 44px;"
+		>
+			Start Tuning
+		</button>
+	{:else if status === 'requesting-permission'}
+		<button
+			disabled
+			class="rounded-full border border-border-default bg-bg-surface/50 px-8 py-3 text-sm font-medium text-text-muted"
+			style="min-height: 44px;"
+		>
+			Listening...
+		</button>
+	{:else}
+		<button
+			onclick={onStop}
+			class="rounded-full border border-accent-red/30 bg-accent-red/15 px-8 py-3 text-sm font-medium text-accent-red transition-all duration-200 hover:border-accent-red/50 hover:bg-accent-red/25"
+			style="min-height: 44px;"
+		>
+			Stop
+		</button>
+	{/if}
+</div>

--- a/frontend/src/lib/tuner-geometry.test.ts
+++ b/frontend/src/lib/tuner-geometry.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect } from 'vitest';
+import {
+	centsToAngle,
+	centsToColorZone,
+	centsToDirection,
+	polarToCartesian,
+	generateTickMarks,
+	describeArc,
+	ANGLE_MAX,
+	ANGLE_MIN,
+	GREEN_THRESHOLD,
+	YELLOW_THRESHOLD
+} from './tuner-geometry';
+
+describe('centsToAngle', () => {
+	it('maps 0 cents to 0 degrees', () => {
+		expect(centsToAngle(0)).toBe(0);
+	});
+
+	it('maps -50 cents to -135 degrees', () => {
+		expect(centsToAngle(-50)).toBe(ANGLE_MIN);
+	});
+
+	it('maps +50 cents to +135 degrees', () => {
+		expect(centsToAngle(50)).toBe(ANGLE_MAX);
+	});
+
+	it('clamps values beyond -50', () => {
+		expect(centsToAngle(-100)).toBe(ANGLE_MIN);
+	});
+
+	it('clamps values beyond +50', () => {
+		expect(centsToAngle(100)).toBe(ANGLE_MAX);
+	});
+
+	it('is linear — 25 cents maps to half the max angle', () => {
+		expect(centsToAngle(25)).toBe(ANGLE_MAX / 2);
+		expect(centsToAngle(-25)).toBe(ANGLE_MIN / 2);
+	});
+});
+
+describe('centsToColorZone', () => {
+	it('returns green at 0 cents', () => {
+		expect(centsToColorZone(0)).toBe('green');
+	});
+
+	it('returns green at boundary (±5 cents)', () => {
+		expect(centsToColorZone(GREEN_THRESHOLD)).toBe('green');
+		expect(centsToColorZone(-GREEN_THRESHOLD)).toBe('green');
+	});
+
+	it('returns yellow just outside green zone', () => {
+		expect(centsToColorZone(GREEN_THRESHOLD + 1)).toBe('yellow');
+		expect(centsToColorZone(-(GREEN_THRESHOLD + 1))).toBe('yellow');
+	});
+
+	it('returns yellow at yellow boundary (±15 cents)', () => {
+		expect(centsToColorZone(YELLOW_THRESHOLD)).toBe('yellow');
+		expect(centsToColorZone(-YELLOW_THRESHOLD)).toBe('yellow');
+	});
+
+	it('returns red outside yellow zone', () => {
+		expect(centsToColorZone(YELLOW_THRESHOLD + 1)).toBe('red');
+		expect(centsToColorZone(-(YELLOW_THRESHOLD + 1))).toBe('red');
+	});
+
+	it('returns red at extremes', () => {
+		expect(centsToColorZone(50)).toBe('red');
+		expect(centsToColorZone(-50)).toBe('red');
+	});
+});
+
+describe('centsToDirection', () => {
+	it('returns in-tune at 0 cents', () => {
+		expect(centsToDirection(0)).toBe('in-tune');
+	});
+
+	it('returns in-tune within green threshold', () => {
+		expect(centsToDirection(GREEN_THRESHOLD)).toBe('in-tune');
+		expect(centsToDirection(-GREEN_THRESHOLD)).toBe('in-tune');
+	});
+
+	it('returns flat for negative cents beyond threshold', () => {
+		expect(centsToDirection(-10)).toBe('flat');
+		expect(centsToDirection(-50)).toBe('flat');
+	});
+
+	it('returns sharp for positive cents beyond threshold', () => {
+		expect(centsToDirection(10)).toBe('sharp');
+		expect(centsToDirection(50)).toBe('sharp');
+	});
+});
+
+describe('polarToCartesian', () => {
+	it('0° (straight up) returns point directly above center', () => {
+		const { x, y } = polarToCartesian(150, 170, 100, 0);
+		expect(x).toBeCloseTo(150, 5);
+		expect(y).toBeCloseTo(70, 5);
+	});
+
+	it('90° (right) returns point to the right of center', () => {
+		const { x, y } = polarToCartesian(150, 170, 100, 90);
+		expect(x).toBeCloseTo(250, 5);
+		expect(y).toBeCloseTo(170, 5);
+	});
+
+	it('-90° (left) returns point to the left of center', () => {
+		const { x, y } = polarToCartesian(150, 170, 100, -90);
+		expect(x).toBeCloseTo(50, 5);
+		expect(y).toBeCloseTo(170, 5);
+	});
+});
+
+describe('generateTickMarks', () => {
+	const ticks = generateTickMarks();
+
+	it('generates 21 ticks (every 5 cents from -50 to +50)', () => {
+		expect(ticks).toHaveLength(21);
+	});
+
+	it('has 5 major ticks at -50, -25, 0, +25, +50', () => {
+		const majorTicks = ticks.filter((t) => t.major);
+		expect(majorTicks).toHaveLength(5);
+		expect(majorTicks.map((t) => t.cents)).toEqual([-50, -25, 0, 25, 50]);
+	});
+
+	it('tick coordinates are valid numbers', () => {
+		for (const tick of ticks) {
+			expect(tick.x1).toBeTypeOf('number');
+			expect(tick.y1).toBeTypeOf('number');
+			expect(tick.x2).toBeTypeOf('number');
+			expect(tick.y2).toBeTypeOf('number');
+			expect(Number.isFinite(tick.x1)).toBe(true);
+			expect(Number.isFinite(tick.y1)).toBe(true);
+		}
+	});
+});
+
+describe('describeArc', () => {
+	it('returns a valid SVG path string', () => {
+		const d = describeArc(150, 170, 130, -45, 45);
+		expect(d).toMatch(/^M [\d.]+ [\d.]+ A 130 130 0 [01] [01] [\d.]+ [\d.]+$/);
+	});
+
+	it('starts and ends at different points for non-zero arcs', () => {
+		const d = describeArc(150, 170, 130, -90, 90);
+		const parts = d.split(' ');
+		const startX = parseFloat(parts[1]);
+		const endX = parseFloat(parts[parts.length - 2]);
+		expect(startX).not.toBeCloseTo(endX, 0);
+	});
+});

--- a/frontend/src/lib/tuner-geometry.ts
+++ b/frontend/src/lib/tuner-geometry.ts
@@ -1,0 +1,158 @@
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** SVG viewBox dimensions */
+export const GAUGE_WIDTH = 300;
+export const GAUGE_HEIGHT = 200;
+
+/** Gauge arc center and radius */
+export const GAUGE_CX = 150;
+export const GAUGE_CY = 170;
+export const GAUGE_RADIUS = 130;
+
+/** Angle range: -135° (far left / -50 cents) to +135° (far right / +50 cents) */
+export const ANGLE_MIN = -135;
+export const ANGLE_MAX = 135;
+
+/** Cents range */
+export const CENTS_MIN = -50;
+export const CENTS_MAX = 50;
+
+/** Color zone thresholds (absolute cents) */
+export const GREEN_THRESHOLD = 5;
+export const YELLOW_THRESHOLD = 15;
+
+/** Calibration range */
+export const CALIBRATION_MIN = 420;
+export const CALIBRATION_MAX = 460;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type ColorZone = 'green' | 'yellow' | 'red';
+export type Direction = 'flat' | 'sharp' | 'in-tune';
+
+export interface TickMark {
+	cents: number;
+	angle: number;
+	x1: number;
+	y1: number;
+	x2: number;
+	y2: number;
+	major: boolean;
+}
+
+export interface ArcSegment {
+	d: string;
+	color: string;
+}
+
+// ---------------------------------------------------------------------------
+// Pure functions
+// ---------------------------------------------------------------------------
+
+/** Map cents offset (-50..+50) to gauge angle (-135..+135 degrees). Clamps to range. */
+export function centsToAngle(cents: number): number {
+	const clamped = Math.max(CENTS_MIN, Math.min(CENTS_MAX, cents));
+	return (clamped / CENTS_MAX) * ANGLE_MAX;
+}
+
+/** Determine color zone from cents offset. */
+export function centsToColorZone(cents: number): ColorZone {
+	const abs = Math.abs(cents);
+	if (abs <= GREEN_THRESHOLD) return 'green';
+	if (abs <= YELLOW_THRESHOLD) return 'yellow';
+	return 'red';
+}
+
+/** Determine tuning direction from cents offset. */
+export function centsToDirection(cents: number): Direction {
+	if (Math.abs(cents) <= GREEN_THRESHOLD) return 'in-tune';
+	return cents < 0 ? 'flat' : 'sharp';
+}
+
+/** Convert polar coordinates (angle in degrees) to cartesian. 0° = up (12 o'clock). */
+export function polarToCartesian(
+	cx: number,
+	cy: number,
+	radius: number,
+	angleDeg: number
+): { x: number; y: number } {
+	// Convert so that 0° points straight up, positive = clockwise
+	const rad = ((angleDeg - 90) * Math.PI) / 180;
+	return {
+		x: cx + radius * Math.cos(rad),
+		y: cy + radius * Math.sin(rad)
+	};
+}
+
+/** Generate an SVG arc path `d` string between two angles (degrees). */
+export function describeArc(
+	cx: number,
+	cy: number,
+	radius: number,
+	startAngle: number,
+	endAngle: number
+): string {
+	const start = polarToCartesian(cx, cy, radius, startAngle);
+	const end = polarToCartesian(cx, cy, radius, endAngle);
+	const largeArc = Math.abs(endAngle - startAngle) > 180 ? 1 : 0;
+	const sweep = endAngle > startAngle ? 1 : 0;
+	return `M ${start.x} ${start.y} A ${radius} ${radius} 0 ${largeArc} ${sweep} ${end.x} ${end.y}`;
+}
+
+/** Generate tick marks at every 5 cents, major ticks at -50, -25, 0, +25, +50. */
+export function generateTickMarks(): TickMark[] {
+	const majorCents = new Set([-50, -25, 0, 25, 50]);
+	const ticks: TickMark[] = [];
+	const innerRadius = GAUGE_RADIUS - 8;
+	const innerRadiusMajor = GAUGE_RADIUS - 14;
+
+	for (let cents = CENTS_MIN; cents <= CENTS_MAX; cents += 5) {
+		const angle = centsToAngle(cents);
+		const major = majorCents.has(cents);
+		const outer = polarToCartesian(GAUGE_CX, GAUGE_CY, GAUGE_RADIUS, angle);
+		const inner = polarToCartesian(
+			GAUGE_CX,
+			GAUGE_CY,
+			major ? innerRadiusMajor : innerRadius,
+			angle
+		);
+
+		ticks.push({
+			cents,
+			angle,
+			x1: inner.x,
+			y1: inner.y,
+			x2: outer.x,
+			y2: outer.y,
+			major
+		});
+	}
+
+	return ticks;
+}
+
+/** Generate the 5 color arc segments: red–yellow–green–yellow–red. */
+export function generateColorArcs(): ArcSegment[] {
+	const arcRadius = GAUGE_RADIUS + 6;
+	const green = '#5cb870';
+	const yellow = '#d4a053';
+	const red = '#c75450';
+
+	// Boundary angles (cents → angle)
+	const greenStart = centsToAngle(-GREEN_THRESHOLD);
+	const greenEnd = centsToAngle(GREEN_THRESHOLD);
+	const yellowLeftStart = centsToAngle(-YELLOW_THRESHOLD);
+	const yellowRightEnd = centsToAngle(YELLOW_THRESHOLD);
+
+	return [
+		{ d: describeArc(GAUGE_CX, GAUGE_CY, arcRadius, ANGLE_MIN, yellowLeftStart), color: red },
+		{ d: describeArc(GAUGE_CX, GAUGE_CY, arcRadius, yellowLeftStart, greenStart), color: yellow },
+		{ d: describeArc(GAUGE_CX, GAUGE_CY, arcRadius, greenStart, greenEnd), color: green },
+		{ d: describeArc(GAUGE_CX, GAUGE_CY, arcRadius, greenEnd, yellowRightEnd), color: yellow },
+		{ d: describeArc(GAUGE_CX, GAUGE_CY, arcRadius, yellowRightEnd, ANGLE_MAX), color: red }
+	];
+}

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
+	import { resolve } from '$app/paths';
 	import { user, authLoading, logout } from '$lib/stores/auth';
 
 	let mounted = $state(false);
@@ -161,7 +162,8 @@
 				: '16px'});"
 		>
 			<!-- Tuner -->
-			<div
+			<a
+				href={resolve('/tuner')}
 				class="group relative overflow-hidden rounded-2xl border border-border-default bg-bg-surface/50 p-7 backdrop-blur-sm transition-all duration-300 hover:border-accent-green/30 hover:bg-bg-surface/80"
 			>
 				<div
@@ -187,7 +189,7 @@
 						string-by-string guidance.
 					</p>
 				</div>
-			</div>
+			</a>
 
 			<!-- Backing Tracks -->
 			<div

--- a/frontend/src/routes/tuner/+page.svelte
+++ b/frontend/src/routes/tuner/+page.svelte
@@ -1,0 +1,146 @@
+<script lang="ts">
+	import { onMount, onDestroy } from 'svelte';
+	import { resolve } from '$app/paths';
+	import {
+		pitchDetectorState,
+		pitchDetectionResult,
+		pitchDetectionConfig,
+		startPitchDetection,
+		stopPitchDetection,
+		updateConfig
+	} from '$lib/stores/pitch-detector';
+	import TunerGauge from '$lib/components/tuner/TunerGauge.svelte';
+	import NoteDisplay from '$lib/components/tuner/NoteDisplay.svelte';
+	import StabilityIndicator from '$lib/components/tuner/StabilityIndicator.svelte';
+	import CalibrationControl from '$lib/components/tuner/CalibrationControl.svelte';
+	import TunerStatus from '$lib/components/tuner/TunerStatus.svelte';
+
+	let reducedMotion = $state(false);
+	let showFrequency = $state(false);
+
+	onMount(() => {
+		const mq = window.matchMedia('(prefers-reduced-motion: reduce)');
+		reducedMotion = mq.matches;
+		const handler = (e: MediaQueryListEvent) => {
+			reducedMotion = e.matches;
+		};
+		mq.addEventListener('change', handler);
+		return () => mq.removeEventListener('change', handler);
+	});
+
+	onDestroy(() => {
+		stopPitchDetection();
+	});
+
+	function handlePitchCenterChange(value: number) {
+		updateConfig({ pitchCenter: value });
+	}
+</script>
+
+<svelte:head>
+	<title>Tuner — Guitar</title>
+</svelte:head>
+
+<!-- Ambient background (same as landing page) -->
+<div class="fixed inset-0 -z-10 overflow-hidden">
+	<div
+		class="absolute top-1/4 left-1/2 h-[800px] w-[800px] -translate-x-1/2 -translate-y-1/2 rounded-full opacity-20"
+		style="background: radial-gradient(circle, #d4a053 0%, transparent 70%);"
+	></div>
+	<div
+		class="absolute right-0 bottom-0 h-[600px] w-[600px] translate-x-1/4 translate-y-1/4 rounded-full opacity-10"
+		style="background: radial-gradient(circle, #5b8fd4 0%, transparent 70%);"
+	></div>
+	<div
+		class="absolute inset-0 opacity-[0.03]"
+		style="background-image: url('data:image/svg+xml,<svg viewBox=%220 0 256 256%22 xmlns=%22http://www.w3.org/2000/svg%22><filter id=%22n%22><feTurbulence type=%22fractalNoise%22 baseFrequency=%220.9%22 numOctaves=%224%22 stitchTiles=%22stitch%22/></filter><rect width=%22100%25%22 height=%22100%25%22 filter=%22url(%23n)%22/></svg>');"
+	></div>
+</div>
+
+<div class="flex min-h-screen flex-col">
+	<!-- Nav -->
+	<nav class="flex items-center justify-between px-6 py-5 md:px-12">
+		<a
+			href={resolve('/')}
+			class="flex items-center gap-2.5 text-text-secondary transition-colors duration-200 hover:text-text-primary"
+		>
+			<svg width="16" height="16" viewBox="0 0 24 24" fill="none">
+				<path
+					d="M19 12H5m7-7-7 7 7 7"
+					stroke="currentColor"
+					stroke-width="2"
+					stroke-linecap="round"
+					stroke-linejoin="round"
+				/>
+			</svg>
+			<span class="text-sm">Back</span>
+		</a>
+
+		<h1 class="font-display text-lg tracking-wide text-text-primary">Tuner</h1>
+
+		<!-- Frequency toggle -->
+		<button
+			onclick={() => (showFrequency = !showFrequency)}
+			class="flex items-center justify-center rounded-full text-text-secondary transition-colors duration-200 hover:text-text-primary {showFrequency
+				? 'text-accent-amber'
+				: ''}"
+			style="min-height: 44px; min-width: 44px;"
+			aria-label="Toggle frequency display"
+		>
+			<svg width="18" height="18" viewBox="0 0 24 24" fill="none">
+				<circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="1.5" />
+				<path d="M12 16v-4m0-4h.01" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
+			</svg>
+		</button>
+	</nav>
+
+	<!-- Main content -->
+	<main class="flex flex-1 flex-col items-center justify-center px-6 pb-12">
+		<div
+			class="w-full max-w-lg overflow-hidden rounded-2xl border border-border-default bg-bg-surface/50 p-6 backdrop-blur-sm sm:p-8"
+		>
+			<div class="flex flex-col items-center gap-6">
+				<!-- Gauge -->
+				<TunerGauge
+					cents={$pitchDetectionResult.cents}
+					stability={$pitchDetectionResult.stability}
+					isDetecting={$pitchDetectionResult.isDetecting}
+					{reducedMotion}
+				/>
+
+				<!-- Note display -->
+				<NoteDisplay
+					noteName={$pitchDetectionResult.note?.name ?? null}
+					octave={$pitchDetectionResult.note?.octave ?? null}
+					cents={$pitchDetectionResult.cents}
+					frequency={$pitchDetectionResult.frequency}
+					isDetecting={$pitchDetectionResult.isDetecting}
+					{showFrequency}
+				/>
+
+				<!-- Stability bar -->
+				<div class="w-full max-w-xs">
+					<StabilityIndicator
+						stability={$pitchDetectionResult.stability}
+						isDetecting={$pitchDetectionResult.isDetecting}
+					/>
+				</div>
+
+				<!-- Start/Stop + errors -->
+				<TunerStatus
+					status={$pitchDetectorState.status}
+					error={$pitchDetectorState.error}
+					isDetecting={$pitchDetectionResult.isDetecting}
+					onStart={startPitchDetection}
+					onStop={stopPitchDetection}
+				/>
+
+				<!-- Calibration -->
+				<CalibrationControl
+					pitchCenter={$pitchDetectionConfig.pitchCenter}
+					onPitchCenterChange={handlePitchCenterChange}
+				/>
+			</div>
+		</div>
+	</main>
+</div>

--- a/frontend/src/routes/tuner/+page.svelte
+++ b/frontend/src/routes/tuner/+page.svelte
@@ -123,6 +123,7 @@
 					<StabilityIndicator
 						stability={$pitchDetectionResult.stability}
 						isDetecting={$pitchDetectionResult.isDetecting}
+						{reducedMotion}
 					/>
 				</div>
 


### PR DESCRIPTION
## Summary

- Implements the visual tuner interface (issue #8) that consumes pitch detection stores from #7
- Adds SVG gauge with animated needle (tweened 150ms cubicOut), 5 color-zone arcs (red-yellow-green-yellow-red), tick marks, and Flat/Sharp labels
- Adds note display with 60-72px note name, cents readout with color coding, directional hints ("Tune Up"/"Tune Down"/"In Tune"), and optional frequency toggle
- Adds stability bar, A432/A440 calibration presets with custom stepper, and start/stop button with error handling for all mic permission states
- Adds `tuner-geometry.ts` pure math module with 24 unit tests covering angle mapping, color zones, direction, arc generation, and tick marks
- All touch targets ≥44px, `aria-live` screen reader region, `role="meter"` on gauge and stability bar, `prefers-reduced-motion` support

## Files (8 new)

| File | Purpose |
|------|---------|
| `tuner-geometry.ts` | Pure gauge math (centsToAngle, color zones, SVG arcs, ticks) |
| `tuner-geometry.test.ts` | 24 unit tests |
| `TunerGauge.svelte` | SVG gauge with animated needle + green glow |
| `NoteDisplay.svelte` | Note name, cents, directional hints |
| `StabilityIndicator.svelte` | Horizontal stability bar |
| `CalibrationControl.svelte` | A432/A440 presets + custom stepper |
| `TunerStatus.svelte` | Start/stop button + error messages |
| `routes/tuner/+page.svelte` | Page shell wiring everything together |

## Test plan

- [ ] `npm test` — 56 tests pass (24 new geometry tests)
- [ ] `npm run check` — svelte-check clean (0 errors, 0 warnings)
- [ ] `npm run lint` — ESLint clean
- [ ] `npm run build` — production build succeeds
- [ ] Open `/tuner` — page renders with glassmorphic card
- [ ] Click "Start Tuning" — mic permission prompt appears
- [ ] Play a guitar note — gauge needle moves, note/cents update, stability bar fills
- [ ] Reach green zone — glow pulse fires, "In Tune" checkmark appears
- [ ] Click "Stop" — gauge resets to idle state
- [ ] Toggle A432 — cents offset shifts
- [ ] Test on 375px mobile viewport — readable at arm's length

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)