### PR TITLE
Add tuning presets and string-by-string guided mode

### DIFF
--- a/frontend/src/lib/components/tuner/StringGuide.svelte
+++ b/frontend/src/lib/components/tuner/StringGuide.svelte
@@ -1,0 +1,117 @@
+<script lang="ts">
+	import { tunerMode, jumpToString, resetStrings } from '$lib/stores/tuner-mode';
+
+	interface Props {
+		reducedMotion?: boolean;
+	}
+
+	let { reducedMotion = false }: Props = $props();
+
+	let allTuned = $derived($tunerMode.stringStatus.every((s) => s.inTune));
+
+	// Display strings from low E (index 0 = string 6) to high E (index 5 = string 1)
+	let strings = $derived(
+		$tunerMode.activeTuning.notes.map((note, index) => ({
+			note,
+			index,
+			stringNumber: $tunerMode.activeTuning.notes.length - index,
+			status: $tunerMode.stringStatus[index],
+			isCurrent: $tunerMode.currentStringIndex === index
+		}))
+	);
+</script>
+
+<div class="w-full" aria-label="Guitar strings">
+	<div class="flex flex-col gap-1.5" aria-live="polite">
+		{#each strings as { note, index, stringNumber, status, isCurrent } (index)}
+			<button
+				onclick={() => jumpToString(index)}
+				class="flex items-center gap-3 rounded-lg px-3 py-2 text-left transition-all
+					{reducedMotion ? '' : 'duration-200'}
+					{isCurrent && !status.inTune
+					? 'bg-accent-amber/10 ring-1 ring-accent-amber/30'
+					: status.inTune
+						? 'opacity-60'
+						: 'hover:bg-bg-surface/80'}"
+				style="min-height: 44px;"
+				aria-label="String {stringNumber}, {note.name}{note.octave}{status.inTune
+					? ', tuned'
+					: isCurrent
+						? ', currently tuning'
+						: ''}"
+			>
+				<!-- String number badge -->
+				<span
+					class="flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-xs font-semibold
+						{isCurrent && !status.inTune
+						? 'bg-accent-amber/20 text-accent-amber'
+						: status.inTune
+							? 'bg-accent-green/20 text-accent-green'
+							: 'bg-bg-surface text-text-secondary'}"
+				>
+					{stringNumber}
+				</span>
+
+				<!-- Note name -->
+				<span
+					class="flex-1 text-sm font-medium
+						{isCurrent && !status.inTune
+						? 'text-text-primary'
+						: status.inTune
+							? 'text-text-secondary'
+							: 'text-text-secondary'}"
+				>
+					{note.name}{note.octave}
+				</span>
+
+				<!-- Status icon -->
+				{#if status.inTune}
+					<svg
+						width="18"
+						height="18"
+						viewBox="0 0 24 24"
+						fill="none"
+						class="shrink-0 text-accent-green"
+					>
+						<path
+							d="M20 6L9 17l-5-5"
+							stroke="currentColor"
+							stroke-width="2"
+							stroke-linecap="round"
+							stroke-linejoin="round"
+						/>
+					</svg>
+				{:else if isCurrent}
+					<span
+						class="h-2 w-2 shrink-0 rounded-full bg-accent-amber
+							{reducedMotion ? '' : 'animate-pulse'}"
+					></span>
+				{/if}
+			</button>
+		{/each}
+	</div>
+
+	<!-- Completion state -->
+	{#if allTuned}
+		<div
+			class="mt-3 flex flex-col items-center gap-2 rounded-lg bg-accent-green/10 px-4 py-3 text-center"
+		>
+			<span class="text-sm font-medium text-accent-green">All tuned up!</span>
+			<button
+				onclick={resetStrings}
+				class="text-xs text-text-secondary underline decoration-text-secondary/30 transition-colors duration-200 hover:text-text-primary"
+			>
+				Reset
+			</button>
+		</div>
+	{:else}
+		<div class="mt-2 flex justify-center">
+			<button
+				onclick={resetStrings}
+				class="text-xs text-text-secondary transition-colors duration-200 hover:text-text-primary"
+			>
+				Reset
+			</button>
+		</div>
+	{/if}
+</div>

--- a/frontend/src/lib/components/tuner/TuningSelector.svelte
+++ b/frontend/src/lib/components/tuner/TuningSelector.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+	import { TUNING_PRESETS } from '$lib/music-theory';
+	import { tunerMode, selectPreset, selectAutoDetect } from '$lib/stores/tuner-mode';
+
+	function handleChange(event: Event) {
+		const value = (event.target as HTMLSelectElement).value;
+		if (value === 'auto-detect') {
+			selectAutoDetect();
+		} else {
+			const preset = TUNING_PRESETS.find((p) => p.id === value);
+			if (preset) selectPreset(preset);
+		}
+	}
+
+	let selectedValue = $derived(
+		$tunerMode.mode === 'auto-detect' ? 'auto-detect' : $tunerMode.activeTuning.id
+	);
+</script>
+
+<div class="flex flex-col items-center gap-1">
+	<label for="tuning-select" class="text-xs text-text-secondary">Tuning</label>
+	<select
+		id="tuning-select"
+		value={selectedValue}
+		onchange={handleChange}
+		aria-label="Select guitar tuning"
+		class="rounded-lg border border-border-default bg-bg-surface/50 px-3 py-2 text-sm text-text-primary backdrop-blur-sm transition-colors duration-200 hover:border-accent-amber/30 focus:border-accent-amber/50 focus:outline-none focus:ring-1 focus:ring-accent-amber/30"
+		style="min-height: 44px;"
+	>
+		<option value="auto-detect">Auto-detect (chromatic)</option>
+		{#each TUNING_PRESETS as preset (preset.id)}
+			<option value={preset.id}>{preset.name} — {preset.description}</option>
+		{/each}
+	</select>
+</div>

--- a/frontend/src/lib/music-theory.test.ts
+++ b/frontend/src/lib/music-theory.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { frequencyToNote, NOTE_NAMES, GUITAR_STANDARD_TUNING } from './music-theory';
+import {
+	frequencyToNote,
+	NOTE_NAMES,
+	GUITAR_STANDARD_TUNING,
+	TUNING_PRESETS,
+	findClosestString
+} from './music-theory';
 
 describe('NOTE_NAMES', () => {
 	it('has 12 notes starting with C', () => {
@@ -14,6 +20,92 @@ describe('GUITAR_STANDARD_TUNING', () => {
 		expect(GUITAR_STANDARD_TUNING).toHaveLength(6);
 		const names = GUITAR_STANDARD_TUNING.map((n) => `${n.name}${n.octave}`);
 		expect(names).toEqual(['E2', 'A2', 'D3', 'G3', 'B3', 'E4']);
+	});
+});
+
+describe('TUNING_PRESETS', () => {
+	it('has 6 presets', () => {
+		expect(TUNING_PRESETS).toHaveLength(6);
+	});
+
+	it('each preset has 6 strings', () => {
+		for (const preset of TUNING_PRESETS) {
+			expect(preset.notes).toHaveLength(6);
+		}
+	});
+
+	it('Standard preset matches GUITAR_STANDARD_TUNING', () => {
+		const standard = TUNING_PRESETS.find((p) => p.id === 'standard');
+		expect(standard).toBeDefined();
+		expect(standard!.notes).toBe(GUITAR_STANDARD_TUNING);
+	});
+
+	it('each preset has id, name, and description', () => {
+		for (const preset of TUNING_PRESETS) {
+			expect(preset.id).toBeTruthy();
+			expect(preset.name).toBeTruthy();
+			expect(preset.description).toBeTruthy();
+		}
+	});
+});
+
+describe('findClosestString', () => {
+	const standard = TUNING_PRESETS[0];
+
+	it('returns exact match for in-tune string', () => {
+		const detected = { name: 'E' as const, octave: 2, midi: 40, cents: 0, frequency: 82.41 };
+		const result = findClosestString(detected, standard);
+		expect(result).toEqual({ stringIndex: 0, centsOff: 0 });
+	});
+
+	it('returns correct centsOff when slightly sharp', () => {
+		const detected = { name: 'E' as const, octave: 2, midi: 40, cents: 15, frequency: 83.0 };
+		const result = findClosestString(detected, standard);
+		expect(result).not.toBeNull();
+		expect(result!.stringIndex).toBe(0);
+		expect(result!.centsOff).toBe(15);
+	});
+
+	it('returns correct centsOff when slightly flat', () => {
+		const detected = { name: 'A' as const, octave: 2, midi: 45, cents: -10, frequency: 109.0 };
+		const result = findClosestString(detected, standard);
+		expect(result).not.toBeNull();
+		expect(result!.stringIndex).toBe(1);
+		expect(result!.centsOff).toBe(-10);
+	});
+
+	it('finds nearest string when between two strings', () => {
+		// Midi 41 is F2, which is 1 semitone above E2 (40) — within range
+		const detected = { name: 'F' as const, octave: 2, midi: 41, cents: 0, frequency: 87.31 };
+		const result = findClosestString(detected, standard);
+		expect(result).not.toBeNull();
+		expect(result!.stringIndex).toBe(0); // Closest to E2 (1 semitone)
+	});
+
+	it('returns null when more than 1 semitone from any target', () => {
+		// C3 (midi 48) is 2 semitones below D3 (50) and 3 above A2 (45)
+		const detected = { name: 'C' as const, octave: 3, midi: 48, cents: 0, frequency: 130.81 };
+		const result = findClosestString(detected, standard);
+		expect(result).toBeNull();
+	});
+
+	it('works with Drop D low string', () => {
+		const dropD = TUNING_PRESETS.find((p) => p.id === 'drop-d')!;
+		const detected = { name: 'D' as const, octave: 2, midi: 38, cents: 5, frequency: 73.6 };
+		const result = findClosestString(detected, dropD);
+		expect(result).not.toBeNull();
+		expect(result!.stringIndex).toBe(0);
+		expect(result!.centsOff).toBe(5);
+	});
+
+	it('selects correct string when multiple are close in midi', () => {
+		// Open G has D2(38), G2(43), D3(50), G3(55), B3(59), D4(62)
+		const openG = TUNING_PRESETS.find((p) => p.id === 'open-g')!;
+		const detected = { name: 'G' as const, octave: 3, midi: 55, cents: -3, frequency: 195.5 };
+		const result = findClosestString(detected, openG);
+		expect(result).not.toBeNull();
+		expect(result!.stringIndex).toBe(3); // G3 string
+		expect(result!.centsOff).toBe(-3);
 	});
 });
 

--- a/frontend/src/lib/music-theory.ts
+++ b/frontend/src/lib/music-theory.ts
@@ -33,6 +33,122 @@ export const GUITAR_STANDARD_TUNING: readonly NoteInfo[] = [
 	{ name: 'E', octave: 4, midi: 64, cents: 0, frequency: 329.63 }
 ];
 
+// ---------------------------------------------------------------------------
+// Guitar Tuning Presets
+// ---------------------------------------------------------------------------
+
+export interface GuitarTuning {
+	id: string;
+	name: string;
+	description: string;
+	notes: readonly NoteInfo[];
+}
+
+export const TUNING_PRESETS: readonly GuitarTuning[] = [
+	{
+		id: 'standard',
+		name: 'Standard',
+		description: 'Default EADGBE tuning',
+		notes: GUITAR_STANDARD_TUNING
+	},
+	{
+		id: 'drop-d',
+		name: 'Drop D',
+		description: 'Rock & metal essentials',
+		notes: [
+			{ name: 'D', octave: 2, midi: 38, cents: 0, frequency: 73.42 },
+			{ name: 'A', octave: 2, midi: 45, cents: 0, frequency: 110.0 },
+			{ name: 'D', octave: 3, midi: 50, cents: 0, frequency: 146.83 },
+			{ name: 'G', octave: 3, midi: 55, cents: 0, frequency: 196.0 },
+			{ name: 'B', octave: 3, midi: 59, cents: 0, frequency: 246.94 },
+			{ name: 'E', octave: 4, midi: 64, cents: 0, frequency: 329.63 }
+		]
+	},
+	{
+		id: 'half-step-down',
+		name: 'Half-Step Down',
+		description: 'Eb tuning — SRV, Hendrix',
+		notes: [
+			{ name: 'D#', octave: 2, midi: 39, cents: 0, frequency: 77.78 },
+			{ name: 'G#', octave: 2, midi: 44, cents: 0, frequency: 103.83 },
+			{ name: 'C#', octave: 3, midi: 49, cents: 0, frequency: 138.59 },
+			{ name: 'F#', octave: 3, midi: 54, cents: 0, frequency: 185.0 },
+			{ name: 'A#', octave: 3, midi: 58, cents: 0, frequency: 233.08 },
+			{ name: 'D#', octave: 4, midi: 63, cents: 0, frequency: 311.13 }
+		]
+	},
+	{
+		id: 'open-g',
+		name: 'Open G',
+		description: 'Blues & slide guitar',
+		notes: [
+			{ name: 'D', octave: 2, midi: 38, cents: 0, frequency: 73.42 },
+			{ name: 'G', octave: 2, midi: 43, cents: 0, frequency: 98.0 },
+			{ name: 'D', octave: 3, midi: 50, cents: 0, frequency: 146.83 },
+			{ name: 'G', octave: 3, midi: 55, cents: 0, frequency: 196.0 },
+			{ name: 'B', octave: 3, midi: 59, cents: 0, frequency: 246.94 },
+			{ name: 'D', octave: 4, midi: 62, cents: 0, frequency: 293.66 }
+		]
+	},
+	{
+		id: 'open-d',
+		name: 'Open D',
+		description: 'Folk & fingerstyle',
+		notes: [
+			{ name: 'D', octave: 2, midi: 38, cents: 0, frequency: 73.42 },
+			{ name: 'A', octave: 2, midi: 45, cents: 0, frequency: 110.0 },
+			{ name: 'D', octave: 3, midi: 50, cents: 0, frequency: 146.83 },
+			{ name: 'F#', octave: 3, midi: 54, cents: 0, frequency: 185.0 },
+			{ name: 'A', octave: 3, midi: 57, cents: 0, frequency: 220.0 },
+			{ name: 'D', octave: 4, midi: 62, cents: 0, frequency: 293.66 }
+		]
+	},
+	{
+		id: 'dadgad',
+		name: 'DADGAD',
+		description: 'Celtic & ambient textures',
+		notes: [
+			{ name: 'D', octave: 2, midi: 38, cents: 0, frequency: 73.42 },
+			{ name: 'A', octave: 2, midi: 45, cents: 0, frequency: 110.0 },
+			{ name: 'D', octave: 3, midi: 50, cents: 0, frequency: 146.83 },
+			{ name: 'G', octave: 3, midi: 55, cents: 0, frequency: 196.0 },
+			{ name: 'A', octave: 3, midi: 57, cents: 0, frequency: 220.0 },
+			{ name: 'D', octave: 4, midi: 62, cents: 0, frequency: 293.66 }
+		]
+	}
+] as const;
+
+/**
+ * Find the closest string in a tuning for a detected note.
+ * Returns null if the detected note is more than 1 semitone from any target.
+ */
+export function findClosestString(
+	detectedNote: NoteInfo,
+	tuning: GuitarTuning
+): { stringIndex: number; centsOff: number } | null {
+	let bestIndex = -1;
+	let bestDistance = Infinity;
+
+	for (let i = 0; i < tuning.notes.length; i++) {
+		const target = tuning.notes[i];
+		const semitoneDiff = detectedNote.midi - target.midi;
+		const distance = Math.abs(semitoneDiff * 100 + detectedNote.cents);
+
+		if (distance < bestDistance) {
+			bestDistance = distance;
+			bestIndex = i;
+		}
+	}
+
+	// Reject if more than 1 semitone (100 cents) away
+	if (bestDistance > 100) return null;
+
+	const target = tuning.notes[bestIndex];
+	const centsOff = (detectedNote.midi - target.midi) * 100 + detectedNote.cents;
+
+	return { stringIndex: bestIndex, centsOff };
+}
+
 /**
  * Convert a frequency in Hz to the nearest musical note.
  * @param freq - frequency in Hz

--- a/frontend/src/lib/stores/tuner-mode.test.ts
+++ b/frontend/src/lib/stores/tuner-mode.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { get } from 'svelte/store';
+import {
+	tunerMode,
+	selectPreset,
+	selectAutoDetect,
+	resetStrings,
+	jumpToString,
+	updateGuidedState,
+	_resetInternals,
+	type PitchInput
+} from './tuner-mode';
+import { TUNING_PRESETS } from '$lib/music-theory';
+
+function getState() {
+	return get(tunerMode);
+}
+
+describe('tuner-mode store', () => {
+	beforeEach(() => {
+		selectPreset(TUNING_PRESETS[0]); // Reset to Standard
+		_resetInternals();
+	});
+
+	describe('initial state', () => {
+		it('defaults to guided mode with Standard tuning', () => {
+			const s = getState();
+			expect(s.mode).toBe('guided');
+			expect(s.activeTuning.id).toBe('standard');
+			expect(s.currentStringIndex).toBe(0);
+		});
+
+		it('has 6 strings all not in tune', () => {
+			const s = getState();
+			expect(s.stringStatus).toHaveLength(6);
+			for (const status of s.stringStatus) {
+				expect(status.inTune).toBe(false);
+				expect(status.inTuneSince).toBeNull();
+			}
+		});
+	});
+
+	describe('selectPreset', () => {
+		it('changes tuning and resets string status', () => {
+			const dropD = TUNING_PRESETS.find((p) => p.id === 'drop-d')!;
+			selectPreset(dropD);
+			const s = getState();
+			expect(s.activeTuning.id).toBe('drop-d');
+			expect(s.mode).toBe('guided');
+			expect(s.currentStringIndex).toBe(0);
+			expect(s.stringStatus.every((st) => !st.inTune)).toBe(true);
+		});
+	});
+
+	describe('selectAutoDetect', () => {
+		it('switches to auto-detect mode', () => {
+			selectAutoDetect();
+			const s = getState();
+			expect(s.mode).toBe('auto-detect');
+			expect(s.currentStringIndex).toBeNull();
+		});
+	});
+
+	describe('resetStrings', () => {
+		it('clears all string status and resets to string 0', () => {
+			jumpToString(3);
+			resetStrings();
+			const s = getState();
+			expect(s.currentStringIndex).toBe(0);
+			expect(s.stringStatus.every((st) => !st.inTune)).toBe(true);
+		});
+	});
+
+	describe('jumpToString', () => {
+		it('sets current string index', () => {
+			jumpToString(4);
+			expect(getState().currentStringIndex).toBe(4);
+		});
+
+		it('ignores out-of-range index', () => {
+			jumpToString(4);
+			jumpToString(10);
+			expect(getState().currentStringIndex).toBe(4);
+		});
+
+		it('ignores negative index', () => {
+			jumpToString(2);
+			jumpToString(-1);
+			expect(getState().currentStringIndex).toBe(2);
+		});
+	});
+
+	describe('updateGuidedState', () => {
+		it('ignores updates when not detecting', () => {
+			const pitch: PitchInput = {
+				note: { name: 'E', octave: 2, midi: 40, cents: 0, frequency: 82.41 },
+				stability: 0.9,
+				isDetecting: false
+			};
+			updateGuidedState(pitch, 1000);
+			expect(getState().currentStringIndex).toBe(0);
+		});
+
+		it('ignores updates when note is null', () => {
+			const pitch: PitchInput = { note: null, stability: 0.9, isDetecting: true };
+			updateGuidedState(pitch, 1000);
+			expect(getState().currentStringIndex).toBe(0);
+		});
+
+		it('ignores updates in auto-detect mode', () => {
+			selectAutoDetect();
+			const pitch: PitchInput = {
+				note: { name: 'E', octave: 2, midi: 40, cents: 0, frequency: 82.41 },
+				stability: 0.9,
+				isDetecting: true
+			};
+			updateGuidedState(pitch, 1000);
+			expect(getState().currentStringIndex).toBeNull();
+		});
+
+		it('detects current string from pitch', () => {
+			const pitch: PitchInput = {
+				note: { name: 'A', octave: 2, midi: 45, cents: 3, frequency: 110.2 },
+				stability: 0.5,
+				isDetecting: true
+			};
+			updateGuidedState(pitch, 1000);
+			expect(getState().currentStringIndex).toBe(1);
+		});
+
+		it('marks string in-tune after sustained hold', () => {
+			const pitch: PitchInput = {
+				note: { name: 'E', octave: 2, midi: 40, cents: 2, frequency: 82.5 },
+				stability: 0.9,
+				isDetecting: true
+			};
+
+			// Start tracking
+			updateGuidedState(pitch, 1000);
+			expect(getState().stringStatus[0].inTune).toBe(false);
+			expect(getState().stringStatus[0].inTuneSince).toBe(1000);
+
+			// Still in tune at 999ms — not yet
+			updateGuidedState(pitch, 1999);
+			expect(getState().stringStatus[0].inTune).toBe(false);
+
+			// Hit 1000ms — should mark complete
+			updateGuidedState(pitch, 2000);
+			expect(getState().stringStatus[0].inTune).toBe(true);
+		});
+
+		it('resets timer when pitch drifts out of tune', () => {
+			const inTune: PitchInput = {
+				note: { name: 'E', octave: 2, midi: 40, cents: 2, frequency: 82.5 },
+				stability: 0.9,
+				isDetecting: true
+			};
+			const outOfTune: PitchInput = {
+				note: { name: 'E', octave: 2, midi: 40, cents: 20, frequency: 83.5 },
+				stability: 0.9,
+				isDetecting: true
+			};
+
+			updateGuidedState(inTune, 1000);
+			expect(getState().stringStatus[0].inTuneSince).toBe(1000);
+
+			updateGuidedState(outOfTune, 1500);
+			expect(getState().stringStatus[0].inTuneSince).toBeNull();
+		});
+
+		it('auto-advances to next un-tuned string after marking complete', () => {
+			const pitch: PitchInput = {
+				note: { name: 'E', octave: 2, midi: 40, cents: 0, frequency: 82.41 },
+				stability: 0.9,
+				isDetecting: true
+			};
+
+			updateGuidedState(pitch, 1000);
+			updateGuidedState(pitch, 2000);
+
+			const s = getState();
+			expect(s.stringStatus[0].inTune).toBe(true);
+			expect(s.currentStringIndex).toBe(1); // Advanced to string 1
+		});
+
+		it('resets timer when stability is too low', () => {
+			const lowStability: PitchInput = {
+				note: { name: 'E', octave: 2, midi: 40, cents: 2, frequency: 82.5 },
+				stability: 0.3,
+				isDetecting: true
+			};
+			const highStability: PitchInput = {
+				note: { name: 'E', octave: 2, midi: 40, cents: 2, frequency: 82.5 },
+				stability: 0.9,
+				isDetecting: true
+			};
+
+			updateGuidedState(highStability, 1000);
+			expect(getState().stringStatus[0].inTuneSince).toBe(1000);
+
+			updateGuidedState(lowStability, 1200);
+			expect(getState().stringStatus[0].inTuneSince).toBeNull();
+		});
+	});
+});

--- a/frontend/src/lib/stores/tuner-mode.ts
+++ b/frontend/src/lib/stores/tuner-mode.ts
@@ -1,0 +1,193 @@
+import { writable } from 'svelte/store';
+import {
+	TUNING_PRESETS,
+	findClosestString,
+	type GuitarTuning,
+	type NoteInfo
+} from '$lib/music-theory';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type TunerMode = 'auto-detect' | 'guided';
+
+export interface StringStatus {
+	inTune: boolean;
+	inTuneSince: number | null;
+}
+
+export interface TunerModeState {
+	mode: TunerMode;
+	activeTuning: GuitarTuning;
+	stringStatus: StringStatus[];
+	currentStringIndex: number | null;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Cents threshold for considering a string "in tune" */
+const IN_TUNE_CENTS = 5;
+/** Minimum stability required to count as in-tune */
+const IN_TUNE_STABILITY = 0.7;
+/** Milliseconds a string must stay in-tune before marking complete */
+const IN_TUNE_HOLD_MS = 1000;
+/** Minimum ms before switching detected string (debounce) */
+const STRING_DEBOUNCE_MS = 150;
+
+// ---------------------------------------------------------------------------
+// Store
+// ---------------------------------------------------------------------------
+
+function createInitialState(): TunerModeState {
+	return {
+		mode: 'guided',
+		activeTuning: TUNING_PRESETS[0],
+		stringStatus: Array.from({ length: 6 }, () => ({ inTune: false, inTuneSince: null })),
+		currentStringIndex: 0
+	};
+}
+
+export const tunerMode = writable<TunerModeState>(createInitialState());
+
+// ---------------------------------------------------------------------------
+// Internal tracking (not in store to avoid re-renders)
+// ---------------------------------------------------------------------------
+
+let lastStringChangeTime = 0;
+let lastDetectedString: number | null = null;
+
+// ---------------------------------------------------------------------------
+// Actions
+// ---------------------------------------------------------------------------
+
+export function selectPreset(tuning: GuitarTuning): void {
+	lastStringChangeTime = 0;
+	lastDetectedString = null;
+	tunerMode.set({
+		mode: 'guided',
+		activeTuning: tuning,
+		stringStatus: Array.from({ length: tuning.notes.length }, () => ({
+			inTune: false,
+			inTuneSince: null
+		})),
+		currentStringIndex: 0
+	});
+}
+
+export function selectAutoDetect(): void {
+	lastStringChangeTime = 0;
+	lastDetectedString = null;
+	tunerMode.update((s) => ({
+		...s,
+		mode: 'auto-detect',
+		currentStringIndex: null,
+		stringStatus: s.stringStatus.map(() => ({ inTune: false, inTuneSince: null }))
+	}));
+}
+
+export function resetStrings(): void {
+	lastStringChangeTime = 0;
+	lastDetectedString = null;
+	tunerMode.update((s) => ({
+		...s,
+		stringStatus: s.stringStatus.map(() => ({ inTune: false, inTuneSince: null })),
+		currentStringIndex: 0
+	}));
+}
+
+export function jumpToString(index: number): void {
+	tunerMode.update((s) => {
+		if (index < 0 || index >= s.stringStatus.length) return s;
+		return { ...s, currentStringIndex: index };
+	});
+}
+
+// ---------------------------------------------------------------------------
+// Guided state updater — called from the tuner page's $effect
+// ---------------------------------------------------------------------------
+
+export interface PitchInput {
+	note: NoteInfo | null;
+	stability: number;
+	isDetecting: boolean;
+}
+
+export function updateGuidedState(pitch: PitchInput, now: number = Date.now()): void {
+	if (!pitch.note || !pitch.isDetecting) return;
+
+	tunerMode.update((state) => {
+		if (state.mode !== 'guided') return state;
+
+		const match = findClosestString(pitch.note!, state.activeTuning);
+		if (!match) return state;
+
+		const { stringIndex, centsOff } = match;
+
+		// Debounce string switching
+		let newCurrentIndex = state.currentStringIndex;
+		if (stringIndex !== lastDetectedString) {
+			if (now - lastStringChangeTime < STRING_DEBOUNCE_MS) {
+				return state;
+			}
+			lastDetectedString = stringIndex;
+			lastStringChangeTime = now;
+			newCurrentIndex = stringIndex;
+		}
+
+		const newStatus = [...state.stringStatus];
+		const entry = { ...newStatus[stringIndex] };
+
+		if (entry.inTune) {
+			// Already marked complete — don't change
+		} else if (Math.abs(centsOff) <= IN_TUNE_CENTS && pitch.stability >= IN_TUNE_STABILITY) {
+			if (entry.inTuneSince === null) {
+				entry.inTuneSince = now;
+			} else if (now - entry.inTuneSince >= IN_TUNE_HOLD_MS) {
+				entry.inTune = true;
+				entry.inTuneSince = null;
+				// Auto-advance to next un-tuned string
+				const nextUntunedIndex = findNextUntuned(newStatus, stringIndex, entry);
+				if (nextUntunedIndex !== null) {
+					newCurrentIndex = nextUntunedIndex;
+				}
+			}
+		} else {
+			// Drifted out of tune — reset timer
+			entry.inTuneSince = null;
+		}
+
+		newStatus[stringIndex] = entry;
+
+		return {
+			...state,
+			currentStringIndex: newCurrentIndex,
+			stringStatus: newStatus
+		};
+	});
+}
+
+function findNextUntuned(
+	status: StringStatus[],
+	currentIndex: number,
+	updatedCurrent: StringStatus
+): number | null {
+	// Build a temporary array with the current entry updated
+	const tempStatus = [...status];
+	tempStatus[currentIndex] = updatedCurrent;
+
+	// Search forward from current, wrapping around
+	for (let offset = 1; offset <= tempStatus.length; offset++) {
+		const idx = (currentIndex + offset) % tempStatus.length;
+		if (!tempStatus[idx].inTune) return idx;
+	}
+	return null;
+}
+
+/** Reset internal debounce state (for testing) */
+export function _resetInternals(): void {
+	lastStringChangeTime = 0;
+	lastDetectedString = null;
+}


### PR DESCRIPTION
## Summary

- Adds 6 tuning presets (Standard, Drop D, Half-Step Down, Open G, Open D, DADGAD) with a `TuningSelector` dropdown and an "Auto-detect" chromatic fallback
- Adds `StringGuide` component that walks students through each string with amber/green visual states, tap-to-jump, auto-advance after 1s sustained in-tune, and an "All tuned up!" completion state
- Introduces `findClosestString()` pure function and `tuner-mode` store for guided state management with debounced string detection

## Test plan

- [ ] `npm test` — 83 tests pass (27 new)
- [ ] `npm run lint && npm run check` — clean
- [ ] `npm run build` — production build succeeds
- [ ] Open `/tuner` — Standard preset is default, string guide shows 6 strings
- [ ] Click "Start Tuning", play each string — correct string highlights, checkmark after 1s in-tune
- [ ] Tap a string to jump ahead; tap "Reset" to restart
- [ ] Switch to Auto-detect — string guide hides, tuner works as before
- [ ] Switch to Drop D — string 6 shows D instead of E
- [ ] Tune all 6 strings — "All tuned up!" message appears
- [ ] Test on 375px mobile viewport — vertical list readable

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)